### PR TITLE
Add keys to info.plist for Mechanic

### DIFF
--- a/BroadNibBackground.roboFontExt/info.plist
+++ b/BroadNibBackground.roboFontExt/info.plist
@@ -29,5 +29,9 @@
 	<real>1384037563</real>
 	<key>version</key>
 	<string>1.0</string>
+	<key>repository</key>
+	<string>asaumierdemers/BroadNibBackground</string>
+	<key>extensionPath</key>
+	<string>BroadNibBackground.roboFontExt</string>
 </dict>
 </plist> 


### PR DESCRIPTION
I've added the keys necessary to make your RoboFont extension downloadable through the [Mechanic extension manager](https://github.com/jackjennings/Mechanic). Mechanic allows RoboFont users to download extensions that are publicly hosted on Github, and notifies users when an extension has a new version available.
